### PR TITLE
Feature/fix crashes

### DIFF
--- a/MediaManager.Abstractions/Implementations/MediaQueue.cs
+++ b/MediaManager.Abstractions/Implementations/MediaQueue.cs
@@ -44,13 +44,8 @@ namespace Plugin.MediaManager.Abstractions.Implementations
         public IMediaFile Current
         {
             get
-            {
-                if (Count > 0 && Index >= 0)
-                {
-                    return _queue[Index];
-                }
-
-                return null;
+            {               
+                return _current;
             }
         }
 
@@ -414,13 +409,13 @@ namespace Plugin.MediaManager.Abstractions.Implementations
                     if (Count - 1 >= Index && Index >= 0)
                     {
                         current = _queue[Index];
-                    }
 
-                    if (_current != current)
-                    {
-                        _current = current;
-                        OnPropertyChanged(nameof(Current));
-                        QueueMediaChanged?.Invoke(this, new QueueMediaChangedEventArgs(Current));
+                        if (_current != current)
+                        {
+                            _current = current;
+                            OnPropertyChanged(nameof(Current));
+                            QueueMediaChanged?.Invoke(this, new QueueMediaChangedEventArgs(Current));
+                        }
                     }
                 });
 


### PR DESCRIPTION
Attempt to fix PlayerAnalyticsReporter.get_CurrentTrackId (). Replace the Current get calling with _current field instead of calling queue[index] which can be null. Better to contain current file instead of null reference execption.
Cannot reproduce on emulator, no issues found after code change